### PR TITLE
add assoc-if and assoc-some

### DIFF
--- a/src/clj_momo/lib/map.cljc
+++ b/src/clj_momo/lib/map.cljc
@@ -24,3 +24,25 @@
   (apply set/intersection (->> ms
                                (map keys-in)
                                (map set))))
+
+(defn assoc-if
+  "Assoc key/value pairs for some predicate on key-value values
+
+   (assoc-if #(< (count (str %1 %2)) 5) {} :a 1 :b 2)
+   => {:a 1 :b 2}
+   (assoc-if #(< (count (str %1 %2)) 5) {} :waytoolong 1 :b 2)
+   => {:b 2}
+  "
+  ([p m k v]
+   (if (p k v) (assoc m k v) m))
+  ([p m k v & more]
+   (apply assoc-if p (assoc-if p m k v) more)))
+
+(def assoc-some
+  "Assoc key/value pairs for non-nil values
+
+
+   (assoc-some {} :a 1 :b nil :c 3)
+   => {:a 1 :c 3}
+  "
+  (partial assoc-if #(some? %2)))

--- a/test/clj_momo/lib/map_test.clj
+++ b/test/clj_momo/lib/map_test.clj
@@ -10,3 +10,11 @@
 
 (deftest test-keys-in-all
   (is false))
+
+(deftest test-assoc-if
+  (is {:a 10 :c 3}
+      (sut/assoc-if #(< (count (str %1 %2)) 5) {} :a 1 :waytoolong 2 :c 3)))
+
+(deftest test-assoc-some
+  (is {:a 10 :c 3}
+      (sut/assoc-some {} :a 1 :b nil :c 3)))


### PR DESCRIPTION
I use these function in replacement of the

``` clojure
(cond-> m
   v1 (assoc k1 v1)
   v2 (assoc k2 v2)
   v3 (assoc k3 v3)
```

with `assoc-some` we could write

``` clojure
(assoc-some m k1 v1 k2 v2 k3 v3)
```

instead.

and `(assoc-if p m k1 v1 k2 v2 k3 v3)`

could replace

``` clojure
(cond-> m
  (p k1 v1) (assoc k1 v1)
  (p k2 v2) (assoc k2 v2)
  (p k3 v3) (assoc k3 v3))
```
