### PR TITLE
url protection

### DIFF
--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -3,6 +3,7 @@
             [clj-http.client :as client]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
+            [cemerick.url :refer (url url-encode)]
             [clj-momo.lib.es
              [conn :refer [default-opts safe-es-read]]
              [schemas :refer [ESConn Refresh]]
@@ -15,7 +16,7 @@
 (defn create-doc-uri
   "make an uri for document creation"
   [uri index-name mapping id]
-  (format "%s/%s/%s/%s" uri index-name mapping id))
+  (str (url uri (url-encode index-name) (url-encode mapping) (url-encode id))))
 
 (def delete-doc-uri
   "make an uri for doc deletion"
@@ -28,16 +29,16 @@
 (defn update-doc-uri
   "make an uri for document update"
   [uri index-name mapping id]
-  (format "%s/%s/%s/%s/_update" uri index-name mapping id))
+  (str (url uri (url-encode index-name) (url-encode mapping) (url-encode id) "_update")))
 
 (defn bulk-uri
   "make an uri for bulk action"
   [uri]
-  (format "%s/_bulk" uri))
+  (str (url uri "_bulk" )))
 
 (defn search-uri [uri index-name mapping]
   "make an uri for search action"
-  (format "%s/%s/%s/_search" uri index-name mapping))
+  (str (url uri (url-encode index-name) (url-encode mapping) "_search" )))
 
 (def ^:private special-operation-keys
   "all operations fields for a bulk operation"

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -8,13 +8,18 @@
 
 (use-fixtures :once mth/fixture-schema-validation)
 
-(deftest ^:integration create-doc-uri-test
+(deftest create-doc-uri-test
   (testing "should generate a valid doc URI"
     (is (= (es-doc/create-doc-uri "http://127.0.0.1"
                                   "test_index"
                                   "test_mapping"
                                   "test")
-           "http://127.0.0.1/test_index/test_mapping/test"))))
+           "http://127.0.0.1/test_index/test_mapping/test"))
+    (is (= (es-doc/create-doc-uri "http://127.0.0.1"
+                                  "test_index"
+                                  "test_mapping"
+                                  "test/foo/bar")
+           "http://127.0.0.1/test_index/test_mapping/test%2Ffoo%2Fbar"))))
 
 (deftest ^:integration document-crud-ops
   (testing "with ES conn test setup"


### PR DESCRIPTION
Some code used keys containing `/` that broke ES calls.

This should fix this problem and also fix a wide range of cross-scripting attack issues. (typically a user trying to add a `/` in its email, or some settings key).