### PR TITLE
Add deep-merge-with

### DIFF
--- a/src/clj_momo/lib/map.cljc
+++ b/src/clj_momo/lib/map.cljc
@@ -46,3 +46,16 @@
    => {:a 1 :c 3}
   "
   (partial assoc-if #(some? %2)))
+
+(defn deep-merge-with
+  "Like merge-with, but merges maps recursively, appling the given fn
+  only when there's a non-map at a particular level.
+  (deep-merge-with + {:a {:b {:c 1 :d {:x 1 :y 2}} :e 3} :f 4}
+                     {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
+  -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}"
+  [f & maps]
+  (if (every? map? maps)
+    (apply merge-with (partial deep-merge-with f) maps)
+    (apply f maps)))
+
+(def deep-merge (partial deep-merge-with (fn [& args] (last args))))

--- a/test/clj_momo/lib/map_test.clj
+++ b/test/clj_momo/lib/map_test.clj
@@ -9,3 +9,17 @@
 (deftest test-assoc-some
   (is {:a 10 :c 3}
       (sut/assoc-some {} :a 1 :b nil :c 3)))
+
+(deftest deep-merge-test
+  (is (= (sut/deep-merge {:a {:aa "ok"
+                              :ab 2}}
+                         {:a {:ab 3
+                              :ac {:aca 0
+                                   :acb "ok"}}}
+                         {:a {:ab "ok" :ac {:aca "ok"
+                                            :acc "ok"}}})
+         {:a {:aa "ok"
+              :ab "ok"
+              :ac {:aca "ok"
+                   :acb "ok"
+                   :acc "ok"}}})))


### PR DESCRIPTION
Like `merge-with`, but merges maps recursively

```clojure
(deep-merge-with + {:a {:b {:c 1 :d {:x 1 :y 2}} :e 3} :f 4}
                   {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
  -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}
```

