### PR TITLE
CLJS UtcDateTime is an Inst (for easier specs)

### DIFF
--- a/src/clj_momo/lib/clj_time/core.cljc
+++ b/src/clj_momo/lib/clj_time/core.cljc
@@ -593,3 +593,9 @@
 
    :cljs
    (def within? time-delegate/within?))
+
+#?(:cljs
+   (extend-protocol cljs.core/Inst
+     goog.date.UtcDateTime
+     (inst-ms* [dt]
+       (.getTime dt))))


### PR DESCRIPTION
We tend to use UtcDateTime objects in CLJS, but that isn't an Inst by default (normally that would be a js/Date).  We want to be able to use 'inst? as a predicate when writing specs.