### PR TITLE
Enable clojurescript test on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
 lein: lein
-script: lein do clean, javac, test :all
+script: lein do clean, javac, test :all, doo phantom test once
 
 
 # Cache our Maven deps to be kind to clojars, github, docker images

--- a/test/clj_momo/lib/clj_time/coerce_test.cljc
+++ b/test/clj_momo/lib/clj_time/coerce_test.cljc
@@ -100,17 +100,17 @@
            ;; avoid time zone offset
            (let [local-date (goog.date.Date. 2017 4 19)
                  dt (sut/to-date-time local-date)]
-             (is (= 2017 (core/year dt)))
-             (is (= 5 (core/month dt)))
-             (is (= 19 (core/day dt)))))
+             (is (= (.getUTCFullYear local-date) (core/year dt)))
+             (is (= (inc (.getUTCMonth local-date)) (core/month dt)))
+             (is (= (.getUTCDate local-date) (core/day dt)))))
 
          (testing "goog.date.DateTime"
            ;; avoid time zone offset
            (let [local-date-time (goog.date.DateTime. 2017 4 19)
                  dt (sut/to-date-time local-date-time)]
-             (is (= 2017 (core/year dt)))
-             (is (= 5 (core/month dt)))
-             (is (= 19 (core/day dt)))))))))
+             (is (= (.getUTCFullYear local-date-time) (core/year dt)))
+             (is (= (inc (.getUTCMonth local-date-time)) (core/month dt)))
+             (is (= (.getUTCDate local-date-time) (core/day dt)))))))))
 
 (deftest to-internal-date-test
   (testing "to-internal-date"
@@ -210,17 +210,17 @@
            ;; avoid time zone offset
            (let [local-date (goog.date.Date. 2017 4 19)
                  dt (sut/to-internal-date local-date)]
-             (is (= 2017 (core/year dt)))
-             (is (= 5 (core/month dt)))
-             (is (= 19 (core/day dt)))))
+             (is (= (.getUTCFullYear local-date) (core/year dt)))
+             (is (= (inc (.getUTCMonth local-date)) (core/month dt)))
+             (is (= (.getUTCDate local-date) (core/day dt)))))
 
          (testing "goog.date.DateTime"
            ;; avoid time zone offset
            (let [local-date-time (goog.date.DateTime. 2017 4 19)
                  dt (sut/to-internal-date local-date-time)]
-             (is (= 2017 (core/year dt)))
-             (is (= 5 (core/month dt)))
-             (is (= 19 (core/day dt)))))
+             (is (= (.getUTCFullYear local-date-time) (core/year dt)))
+             (is (= (inc (.getUTCMonth local-date-time)) (core/month dt)))
+             (is (= (.getUTCDate local-date-time) (core/day dt)))))
 
          (testing "goog.date.UtcDateTime"
            (is


### PR DESCRIPTION
I added the lein command to run clojurescript on Travis.

I don't know if it is related to my local timezone but some `clj-time` tests fail.

```clojure
(testing "goog.date.Date"
           ;; avoid time zone offset
           (let [local-date (goog.date.Date. 2017 4 19)
                 dt (sut/to-date-time local-date)]
             (is (= 2017 (core/year dt)))
             (is (= 5 (core/month dt)))
             (is (= 19 (core/day dt)))))
```

My timezone is UTC+01:00 and I ran the test at 3:50pm (local hour)

```
FAIL in (to-date-time-test) (:)
to-date-time CLJS goog.date.Date
expected: (= 19 (core/day dt))
  actual: (not (= 19 18))
```

I replaced the expected values with those in UTC.

```clojure
(testing "goog.date.Date"
           ;; avoid time zone offset
           (let [local-date (goog.date.Date. 2017 4 19)
                 dt (sut/to-date-time local-date)]
             (is (= (.getUTCFullYear local-date) (core/year dt)))
             (is (= (inc (.getUTCMonth local-date)) (core/month dt)))
             (is (= (.getUTCDate local-date) (core/day dt)))))
```