### PR TITLE
Improving the with-test-logging helper

### DIFF
--- a/src/clj_momo/test_helpers/logging.clj
+++ b/src/clj_momo/test_helpers/logging.clj
@@ -3,29 +3,47 @@
    [clojure.tools.logging :refer [*logger-factory*]]
    [clojure.tools.logging.impl :as impl]))
 
-;; ----- Logging test helpers coming from the tools.logging test code
+;; ----- Logging test helpers based on code from the tools.logging test code
 ;; See https://github.com/clojure/tools.logging/blob/master/src/test/clojure/clojure/tools/test_logging.clj for usage
 
-(defn test-factory [enabled-set entries-atom agent-used-atom]
-  (let [main-thread (Thread/currentThread)]
+(defn get-current-thread []
+  (Thread/currentThread))
+
+(defn test-factory [enabled-set
+                    last-log-entry-atom
+                    agent-used-atom
+                    all-log-entries-atom]
+  (let [main-thread (get-current-thread)]
     (reify impl/LoggerFactory
       (name [_] "test factory")
       (get-logger [_ log-ns]
         (reify impl/Logger
           (enabled? [_ level] (contains? enabled-set level))
           (write! [_ lvl ex msg]
-            (reset! entries-atom [(str log-ns) lvl ex msg])
-            (reset! agent-used-atom (not (identical? main-thread (Thread/currentThread))))))))))
+            (let [log-data [(str log-ns) lvl ex msg]]
+              (swap! all-log-entries-atom (fnil conj []) log-data)
+              (reset! last-log-entry-atom log-data))
+            (reset! agent-used-atom
+                    (not (identical? main-thread (get-current-thread))))))))))
 
 (defmacro with-test-logging
-  [[enabled-level-set log-entry-sym agent-used?-sym] & body]
+  [[enabled-level-set last-log-entry-sym agent-used?-sym all-log-entries-sym] & body]
   (let [enabled-level-set (or enabled-level-set #{:trace :debug :info :warn :error :fatal})
-        log-entry-sym (or log-entry-sym 'log-entry-sym)
-        agent-used?-sym (or agent-used?-sym 'agent-used?-sym)]
-    `(let [~log-entry-sym (atom nil)
-           ~agent-used?-sym (atom nil)]
+        last-log-entry-sym (or last-log-entry-sym 'last-log-entry-sym)
+        agent-used?-sym (or agent-used?-sym 'agent-used?-sym)
+        all-log-entries-sym (or all-log-entries-sym 'all-log-entries-sym)]
+    `(let [~last-log-entry-sym (atom nil)
+           ~agent-used?-sym (atom nil)
+           ~all-log-entries-sym (atom nil)]
        (binding [*logger-factory* (test-factory
                                     ~enabled-level-set
-                                    ~log-entry-sym
-                                    ~agent-used?-sym)]
+                                    ~last-log-entry-sym
+                                    ~agent-used?-sym
+                                    ~all-log-entries-sym)]
          ~@body))))
+
+
+(defn was-logged? [log-regex all-log-entries-atom]
+  (boolean
+   (some #(re-find log-regex %)
+         (map #(nth % 3) @all-log-entries-atom))))

--- a/test/clj_momo/test_helpers/logging_test.clj
+++ b/test/clj_momo/test_helpers/logging_test.clj
@@ -1,0 +1,65 @@
+(ns clj-momo.test-helpers.logging-test
+  (:require [clj-momo.test-helpers.logging :as sut]
+            [clojure.test :refer [is deftest testing]]
+            [clojure.tools.logging :as log]))
+
+(deftest test-with-test-logging
+  (testing "with only `last-log-atom` (backwards compat)"
+    (sut/with-test-logging [#{:warn} last-log-atom]
+
+      (log/warn "Test warning log 1")
+      (log/error "Test error log")
+      (log/warn "Test warning log 2")
+      (log/info "Test info log")
+
+      (testing "warning logs can be tested"
+        (let [[_ _ _ last-message] @last-log-atom]
+
+          (is (= "Test warning log 2" last-message))))))
+
+  (testing "with `all-logs-atom`"
+    (sut/with-test-logging [#{:warn} last-log-atom agent-used-atom? all-logs-atom]
+
+      (log/warn "Test warning log 1")
+      (log/error "Test error log")
+      (log/warn "Test warning log 2")
+      (log/info "Test info log")
+
+      (testing "warning logs can be tested"
+        (let [[_ _ _ last-message] @last-log-atom
+              messages (map #(nth % 3) @all-logs-atom)]
+
+          (is (false? @agent-used-atom?))
+          (is (= "Test warning log 2" last-message))
+          (is (= ["Test warning log 1"
+                  "Test warning log 2"] messages)))))))
+
+(deftest test-find-log
+  (testing "can find a log message by regex"
+    (sut/with-test-logging [#{:warn} _ _ all-logs-atom]
+
+      (log/warn "Test warning log 1")
+      (log/error "Test error log")
+      (log/warn "Test warning log 2")
+      (log/info "Test info log")
+
+      (testing "warning logs can be tested"
+        (is (true?  (sut/was-logged? #"warning log 1" all-logs-atom)))
+        (is (true?  (sut/was-logged? #"warning log 2" all-logs-atom)))
+        (is (false? (sut/was-logged? #"foo log"       all-logs-atom)))
+        (is (false? (sut/was-logged? #"error log"     all-logs-atom)))
+        (is (false? (sut/was-logged? #"info log"      all-logs-atom)))))
+
+    (sut/with-test-logging [#{:warn :error} _ _ all-logs-atom]
+
+      (log/warn "Test warning log 1")
+      (log/error "Test error log")
+      (log/warn "Test warning log 2")
+      (log/info "Test info log")
+
+      (testing "warning logs can be tested"
+        (is (true?  (sut/was-logged? #"warning log 1" all-logs-atom)))
+        (is (true?  (sut/was-logged? #"warning log 2" all-logs-atom)))
+        (is (false? (sut/was-logged? #"foo log"       all-logs-atom)))
+        (is (true?  (sut/was-logged? #"error log"     all-logs-atom)))
+        (is (false? (sut/was-logged? #"info log"      all-logs-atom)))))))


### PR DESCRIPTION
Improved `with-test-logging` helper, with tests included!

Allows us to easily test all log messages, not just the last one, in tests.

Closes #29