### PR TITLE
Ensure we don't pass keywords as _source

### DIFF
--- a/src/clj_momo/lib/es/conn.clj
+++ b/src/clj_momo/lib/es/conn.clj
@@ -21,7 +21,7 @@
   (if _source
     (update default-opts
             :query-params
-            #(assoc % :_source (clojure.string/join "," _source)))
+            #(assoc % :_source (clojure.string/join "," (map name  _source))))
     default-opts))
 
 (defn make-connection-manager []


### PR DESCRIPTION
Pretty much self explanatory.

This is an improvement to ensure we don't pass keywords to the ` _source` ES query argument.