### PR TITLE
Add open/close operations to ES index

### DIFF
--- a/src/clj_momo/lib/es/index.clj
+++ b/src/clj_momo/lib/es/index.clj
@@ -73,3 +73,21 @@
                  (merge default-opts
                         {:form-params opts
                          :connection-manager cm})))))
+
+(s/defn open!
+  "open an index"
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str]
+  (safe-es-read
+   (client/post (str (index-uri uri index-name) "/_open")
+                (assoc default-opts
+                       :connection-manager cm))))
+
+(s/defn close!
+  "close an index"
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str]
+  (safe-es-read
+   (client/post (str (index-uri uri index-name) "/_close")
+                (assoc default-opts
+                       :connection-manager cm))))

--- a/test/clj_momo/lib/es/index_test.clj
+++ b/test/clj_momo/lib/es/index_test.clj
@@ -32,6 +32,8 @@
                                 {:settings {:number_of_shards 1
                                             :number_of_replicas 1}})
               index-get-res (es-index/get conn "test_index")
+              index-close-res (es-index/close! conn "test_index")
+              index-open-res (es-index/open! conn "test_index")
               index-delete-res (es-index/delete! conn "test_index")]
 
           (es-index/delete! conn "test_index")
@@ -52,5 +54,6 @@
                             :creation_date
                             :uuid
                             :version)))
-
+          (is (= {:acknowledged true} index-open-res))
+          (is (= {:acknowledged true} index-close-res))
           (is (true? (boolean index-delete-res))))))))


### PR DESCRIPTION
This PR add the ability to open or close an ES index ([Elasticsearch Reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html)).

This will be used in CTIA for testing purposes.