### PR TITLE
Allow the wait_for option for the ElasticSearch refresh param

### DIFF
--- a/src/clj_momo/lib/es/schemas.clj
+++ b/src/clj_momo/lib/es/schemas.clj
@@ -14,7 +14,7 @@
 (s/defschema Refresh
   "ES refresh parameter, see
    https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html"
-  (s/enum true false "wait_for"))
+  (s/enum "true" "false" "wait_for"))
 
 (s/defschema ESSlicing
   {:strategy s/Keyword


### PR DESCRIPTION
Related to threatgrid/ctia#645

This PR adds the `wait_for` option the the `Refresh` schema used by the ElasticSearch client.

The schema is now an enum of String to allow coercion using `string-coercion-matcher`.