### PR TITLE
Change ElasticSearch default sort field

### DIFF
--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -213,7 +213,7 @@
 
 (defn params->pagination
   [{:keys [sort_by sort_order offset limit search_after]
-    :or {sort_by :id
+    :or {sort_by :_doc
          sort_order :asc
          offset 0
          limit pagination/default-limit}}]


### PR DESCRIPTION
Connected to threatgrid/iroh#1955

Replace `:id` by `:_doc` (index order) as the default sort field.

It's the most efficient sort order. It doesn't use the fielddata cache like `:id`

Reference: <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-sort.html>