### PR TITLE
Change the default ES sort field

### DIFF
--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -232,7 +232,7 @@
 
 (defn params->pagination
   [{:keys [sort_by sort_order offset limit search_after]
-    :or {sort_by :_doc
+    :or {sort_by :_uid
          sort_order :asc
          offset 0
          limit pagination/default-limit}}]


### PR DESCRIPTION
We noticed that sorting on `_doc` combined with `search_after` scrolling produces inconsistent results, this is a workaround to mitigate that issue. 