### PR TITLE
count documents, and fixed http verb for search

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-momo "0.2.32-SNAPSHOT"
+(defproject threatgrid/clj-momo "0.2.31"
   :description "Library code produced by the Cisco ThreatGrid team for building swagger backed API services"
   :url "https://github.com/threatgrid/clj-momo"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-momo "0.2.31-SNAPSHOT"
+(defproject threatgrid/clj-momo "0.2.31"
   :description "Library code produced by the Cisco ThreatGrid team for building swagger backed API services"
   :url "https://github.com/threatgrid/clj-momo"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-momo "0.2.31"
+(defproject threatgrid/clj-momo "0.2.31-SNAPSHOT"
   :description "Library code produced by the Cisco ThreatGrid team for building swagger backed API services"
   :url "https://github.com/threatgrid/clj-momo"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-momo "0.2.31"
+(defproject threatgrid/clj-momo "0.2.32-SNAPSHOT"
   :description "Library code produced by the Cisco ThreatGrid team for building swagger backed API services"
   :url "https://github.com/threatgrid/clj-momo"
   :license {:name "Eclipse Public License"

--- a/src/clj_momo/lib/es/conn.clj
+++ b/src/clj_momo/lib/es/conn.clj
@@ -1,7 +1,7 @@
 (ns clj-momo.lib.es.conn
   (:require [clj-http.conn-mgr :refer [make-reusable-conn-manager]]
             [clojure.tools.logging :as log]
-            [clj-momo.lib.es.schemas :refer [ESConn]]
+            [clj-momo.lib.es.schemas :refer [ESConn ConnectParams]]
             [schema.core :as s])
   (:import [org.apache.http.impl.conn PoolingClientConnectionManager
             PoolingHttpClientConnectionManager]))
@@ -32,13 +32,13 @@
 
 (s/defn connect :- ESConn
   "instantiate an ES conn from props"
-  [{:keys [transport host port clustername timeout]
+  [{:keys [transport host port timeout]
     :or {transport :http
-         timeout default-timeout}}]
+         timeout default-timeout}} :- ConnectParams]
 
   {:cm (make-connection-manager
         (cm-options {:timeout timeout}))
-   :uri (format "http://%s:%s" host port)})
+   :uri (format "%s://%s:%s" (name transport) host port)})
 
 (defn safe-es-read [{:keys [status body]
                      :as res}]

--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -265,11 +265,11 @@
    index-name :- s/Str
    mapping :- (s/maybe s/Str)
    query :- (s/maybe ESQuery)]
-   (-> (client/get
+   (-> (client/post
         (count-uri uri index-name mapping)
         (merge default-opts
                (when query
-                 {:body (json/generate-string {:query query})})
+                 {:form-params {:query query}})
                {:connection-manager cm}))
        safe-es-read
        :count))
@@ -287,10 +287,10 @@
    params :- s/Any]
   (let [es-params (generate-es-params query params)
         res (safe-es-read
-             (client/get
+             (client/post
               (search-uri uri index-name mapping)
               (merge default-opts
-                     {:body (json/generate-string es-params)
+                     {:form-params es-params
                       :connection-manager cm})))
         hits (get-in res [:hits :total] 0)
         results (->> res :hits :hits (map :_source))

--- a/src/clj_momo/lib/es/schemas.clj
+++ b/src/clj_momo/lib/es/schemas.clj
@@ -5,6 +5,12 @@
   (:import [org.apache.http.impl.conn PoolingClientConnectionManager
             PoolingHttpClientConnectionManager]))
 
+(s/defschema ConnectParams
+  {:host s/Str
+   :port s/Int
+   (s/optional-key :transport) (s/enum :http :https)
+   (s/optional-key :timeout) s/Int})
+
 (s/defschema ESConn
   "an ES conn is a map with a
    connection manager and an index name"

--- a/src/clj_momo/lib/es/schemas.clj
+++ b/src/clj_momo/lib/es/schemas.clj
@@ -6,10 +6,11 @@
             PoolingHttpClientConnectionManager]))
 
 (s/defschema ConnectParams
-  {:host s/Str
-   :port s/Int
-   (s/optional-key :transport) (s/enum :http :https)
-   (s/optional-key :timeout) s/Int})
+  (st/open-schema
+   {:host s/Str
+    :port s/Int
+    (s/optional-key :transport) (s/enum :http :https)
+    (s/optional-key :timeout) s/Int}))
 
 (s/defschema ESConn
   "an ES conn is a map with a

--- a/test/clj_momo/lib/es/conn_test.clj
+++ b/test/clj_momo/lib/es/conn_test.clj
@@ -1,0 +1,12 @@
+(ns clj-momo.lib.es.conn-test
+  (:require [clj-momo.lib.es.conn :as sut]
+            [clojure.test :refer [deftest is]]))
+
+(deftest connect-test
+  (is (= "https://cisco.com:9201"
+         (:uri (sut/connect {:transport :https
+                             :host "cisco.com"
+                             :port 9201}))))
+  (is (= "http://127.0.0.1:9200"
+         (:uri (sut/connect {:host "127.0.0.1"
+                             :port 9200})))))

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -187,8 +187,6 @@
     (is (apply = (repeatedly 30 query)))
     (es-index/delete! conn "test_index")))
 
-
-
 (deftest ^:integration count-test
   (let [sample-docs (mapv #(assoc {:_index "test_index"
                                    :_type "test_mapping"


### PR DESCRIPTION
Introduces document count.
Fixes bug in `conn/connect` that do not ignore any more `transport`param.