### PR TITLE
full hits in document/query, rollover API support

### DIFF
--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -226,9 +226,7 @@
 
 (s/defn delete-by-query-uri
   [uri index-names mapping]
-  (let [index (if (coll? index-names)
-                (str/join "," index-names)
-                index-names)]
+  (let [index (str/join "," index-names)]
     (str (url uri
               (url-encode index)
               (url-encode mapping)
@@ -237,7 +235,7 @@
 (s/defn delete-by-query
   "delete all documents that match a query in an index"
   [{:keys [uri cm]} :- ESConn
-   index-names :- s/Any
+   index-names :- [s/Str]
    mapping :- (s/maybe s/Str)
    q :- ESQuery
    wait-for-completion? :- s/Bool
@@ -308,14 +306,11 @@
 
 (s/defn query
   "Search for documents on ES using any query."
-  ([es-conn index-name mapping q params]
-   (query es-conn index-name mapping q params false))
-  ([{:keys [uri cm]} :- ESConn
+  [{:keys [uri cm]} :- ESConn
     index-name :- s/Str
     mapping :- s/Str
     q :- ESQuery
-    params :- s/Any
-    full-hits? :- s/Bool]
+    {:keys [full-hits?] :as params} :- s/Any]
    (let [es-params (generate-es-params q params)
          res (safe-es-read
               (client/post
@@ -334,7 +329,7 @@
                                    :limit (:size es-params)
                                    :sort sort
                                    :search_after (:search_after params)
-                                   :hits total-hits}))))
+                                   :hits total-hits})))
 
 (s/defn search-docs
   "Search for documents on ES using a query string search.  Also applies a filter map, converting

--- a/src/clj_momo/lib/es/index.clj
+++ b/src/clj_momo/lib/es/index.clj
@@ -111,7 +111,7 @@
   "refresh an index"
   ([es-conn] (refresh! es-conn nil))
   ([{:keys [uri cm]} :- ESConn
-    index-name :- s/Str]
+    index-name :- (s/maybe s/Str)]
    (safe-es-read
     (client/post (refresh-uri uri index-name)
                  (assoc default-opts

--- a/src/clj_momo/lib/es/index.clj
+++ b/src/clj_momo/lib/es/index.clj
@@ -26,12 +26,9 @@
     alias :- s/Str
     new-index-name :- (s/maybe s/Str)
     dry_run :- s/Bool]
-   (str (index-uri uri alias)
-        "/_rollover"
-        (when new-index-name
-          (str "/" new-index-name))
-        (when dry_run
-          "?dry_run"))))
+   (cond-> (str (index-uri uri alias) "/_rollover")
+        new-index-name (str "/" new-index-name)
+        dry_run (str "?dry_run"))))
 
 (s/defn refresh-uri :- s/Str
   "make a refresh uri from a host, and optionally an index name"

--- a/src/clj_momo/lib/es/index.clj
+++ b/src/clj_momo/lib/es/index.clj
@@ -33,6 +33,15 @@
         (when dry_run
           "?dry_run"))))
 
+(s/defn refresh-uri :- s/Str
+  "make a refresh uri from a host, and optionally an index name"
+  [uri :- s/Str
+   index-name :- (s/maybe s/Str)]
+  (str uri
+       (when index-name
+         (str "/" index-name))
+       "/_refresh"))
+
 (s/defn index-exists? :- s/Bool
   "check if the supplied ES index exists"
   [{:keys [uri cm]} :- ESConn
@@ -100,12 +109,13 @@
 
 (s/defn refresh!
   "refresh an index"
-  [{:keys [uri cm]} :- ESConn
-   index-name :- s/Str]
-  (safe-es-read
-   (client/post (str (index-uri uri index-name) "/_refresh")
-                (assoc default-opts
-                       :connection-manager cm))))
+  ([es-conn] (refresh! es-conn nil))
+  ([{:keys [uri cm]} :- ESConn
+    index-name :- s/Str]
+   (safe-es-read
+    (client/post (refresh-uri uri index-name)
+                 (assoc default-opts
+                        :connection-manager cm)))))
 
 (s/defn open!
   "open an index"

--- a/src/clj_momo/lib/es/index.clj
+++ b/src/clj_momo/lib/es/index.clj
@@ -1,6 +1,7 @@
 (ns clj-momo.lib.es.index
   (:refer-clojure :exclude [get])
   (:require [clj-http.client :as client]
+            [cemerick.url :refer [url-encode]]
             [clj-momo.lib.es
              [conn :refer [default-opts safe-es-read]]
              [schemas :refer [ESConn RolloverConditions]]]
@@ -10,14 +11,18 @@
   "make an index uri from a host and an index name"
   [uri :- s/Str
    index-name :- s/Str]
-  (format "%s/%s" uri index-name))
+  (format "%s/%s"
+          uri
+          (url-encode index-name)))
 
 (s/defn template-uri :- s/Str
   "make a template uri from a host and a template name"
   [uri :- s/Str
    template-name :- s/Str]
   "make a template uri from a host and a template name"
-  (format "%s/_template/%s" uri template-name))
+  (format "%s/_template/%s"
+          uri
+          (url-encode template-name)))
 
 (s/defn rollover-uri :- s/Str
   "make a rollover uri from a host and an index name"
@@ -27,7 +32,7 @@
     new-index-name :- (s/maybe s/Str)
     dry_run :- s/Bool]
    (cond-> (str (index-uri uri alias) "/_rollover")
-        new-index-name (str "/" new-index-name)
+        new-index-name (str "/" (url-encode new-index-name))
         dry_run (str "?dry_run"))))
 
 (s/defn refresh-uri :- s/Str
@@ -36,7 +41,7 @@
    index-name :- (s/maybe s/Str)]
   (str uri
        (when index-name
-         (str "/" index-name))
+         (str "/" (url-encode index-name)))
        "/_refresh"))
 
 (s/defn index-exists? :- s/Bool

--- a/src/clj_momo/lib/es/query.clj
+++ b/src/clj_momo/lib/es/query.clj
@@ -1,8 +1,12 @@
 (ns clj-momo.lib.es.query
   (:require [clojure.string :as str]
             [schema.core :as s]
-            [clj-momo.lib.es.schemas :refer :all]
-            ))
+            [clj-momo.lib.es.schemas :refer [IdsQuery BoolQuery BoolQueryParams]]))
+
+(s/defn ids :- IdsQuery
+  "Ids Query"
+  [ids :- [s/Str]]
+  {:ids {:values ids}})
 
 (s/defn bool :- BoolQuery
   "Boolean Query"

--- a/src/clj_momo/lib/es/schemas.clj
+++ b/src/clj_momo/lib/es/schemas.clj
@@ -65,3 +65,14 @@
 (s/defschema BoolQuery
   "Bool query"
   {:bool BoolQueryParams})
+
+(s/defschema IdsQuery
+  "Ids query"
+  {:ids {:values [s/Str]}})
+
+(s/defschema RolloverConditions
+  "Rollover conditions"
+  (st/optional-keys
+   {:max_age s/Str
+    :max_docs s/Int
+    :max_size s/Str}))

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -16,11 +16,11 @@
   (testing "should generate a valid delete_by_query uri"
     (is (= "http://localhost:9200/ctim/_delete_by_query"
            (es-doc/delete-by-query-uri "http://localhost:9200"
-                                       "ctim"
+                                       ["ctim"]
                                        nil)))
     (is (= "http://localhost:9200/ctim/malware/_delete_by_query"
            (es-doc/delete-by-query-uri "http://localhost:9200"
-                                       "ctim"
+                                       ["ctim"]
                                        "malware")))
     (is (= "http://localhost:9200/ctim%2Cctia/malware/_delete_by_query"
            (es-doc/delete-by-query-uri "http://localhost:9200"
@@ -243,8 +243,7 @@
                                          "test_index"
                                          "test_mapping"
                                          (query/ids sample-3-ids)
-                                         {}
-                                         true)]
+                                         {:full-hits? true})]
     (is (= (repeat 3 {:foo "bar"})
            (:data ids-query-result-1))
         "querying with ids query without full-hits? param should return only source of selected docs in :data")

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -12,6 +12,21 @@
   mth/fixture-schema-validation
   th/fixture-properties)
 
+(deftest search-uri-test
+  (testing "should generate a valid _search uri"
+    (is (= "http://localhost:9200/ctia_tool/tool/_search"
+           (es-doc/search-uri "http://localhost:9200"
+                                       "ctia_tool"
+                                       "tool")))
+    (is (= "http://localhost:9200/ctia_tool/_search"
+           (es-doc/search-uri "http://localhost:9200"
+                                       "ctia_tool"
+                                       nil)))
+    (is (= "http://localhost:9200/_search"
+           (es-doc/search-uri "http://localhost:9200"
+                                       nil
+                                       nil)))))
+
 (deftest delete-by-query-uri-test
   (testing "should generate a valid delete_by_query uri"
     (is (= "http://localhost:9200/ctim/_delete_by_query"
@@ -144,6 +159,13 @@
                  (es-doc/search-docs conn
                                      "test_index"
                                      "test_mapping"
+                                     {:query_string {:query "bar"}}
+                                     {:test_value 42}
+                                     {:sort_by "test_value"
+                                      :sort_order :desc})
+                 (es-doc/search-docs conn
+                                     "test_index"
+                                     nil
                                      {:query_string {:query "bar"}}
                                      {:test_value 42}
                                      {:sort_by "test_value"

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -215,6 +215,9 @@
         conn (es-conn/connect (th/get-es-config))
         sample-3-docs (->> (shuffle sample-docs)
                            (take 3))
+        _ (es-index/delete! conn "test_index")
+        _ (es-index/create! conn "test_index" {})
+        _ (es-doc/bulk-create-doc conn sample-docs "true")
         ids-query-result-1 (es-doc/query conn
                                          "test_index"
                                          "test_mapping"
@@ -226,10 +229,6 @@
                                          (query/ids (map :_id sample-3-docs))
                                          {}
                                          true)]
-    (es-index/delete! conn "test_index")
-    (es-index/create! conn "test_index" {})
-    (es-doc/bulk-create-doc conn sample-docs "true")
-
     (is (= (repeat 3 {:foo "bar"})
            (:data ids-query-result-1))
         "querying with ids query without full-hits? param should return only source of selected docs in :data")

--- a/test/clj_momo/lib/es/index_test.clj
+++ b/test/clj_momo/lib/es/index_test.clj
@@ -32,6 +32,12 @@
     (is (= (es-index/rollover-uri "http://127.0.0.1" "test" "test2" false)
            "http://127.0.0.1/test/_rollover/test2"))))
 
+(deftest refresh-uri-test
+  (testing "should generat a proper refresh URI"
+    (is (= (es-index/refresh-uri "http://127.0.0.1" "test-index")
+           "http://127.0.0.1/test-index/_refresh"))
+    (is (= (es-index/refresh-uri "http://127.0.0.1" nil)
+           "http://127.0.0.1/_refresh"))))
 
 (deftest ^:integration index-crud-ops
   (testing "with ES conn test setup"

--- a/test/clj_momo/lib/es/index_test.clj
+++ b/test/clj_momo/lib/es/index_test.clj
@@ -148,6 +148,8 @@
         (is (false? dry_run))
         (is (= old_index "test_index-1"))
         (is (not= old_index new_index))
+        (is (es-index/index-exists? conn old_index))
+        (is (es-index/index-exists? conn new_index))
         (is (= "2" number_of_shards))
         (is (= "3" number_of_replicas))))
 

--- a/test/clj_momo/lib/es/index_test.clj
+++ b/test/clj_momo/lib/es/index_test.clj
@@ -14,12 +14,16 @@
 (deftest index-uri-test
   (testing "should generate a valid index URI"
     (is (= (es-index/index-uri "http://127.0.0.1" "test")
-           "http://127.0.0.1/test"))))
+           "http://127.0.0.1/test"))
+    (is (= (es-index/index-uri "http://127.0.0.1" "<logstash-{now/d}>")
+           "http://127.0.0.1/%3Clogstash-%7Bnow%2Fd%7D%3E"))))
 
 (deftest template-uri-test
   (testing "should generate a valid template URI"
     (is (= (es-index/template-uri "http://127.0.0.1" "test")
-           "http://127.0.0.1/_template/test"))))
+           "http://127.0.0.1/_template/test"))
+    (is (= (es-index/template-uri "http://127.0.0.1" "testé")
+           "http://127.0.0.1/_template/test%C3%A9"))))
 
 (deftest rollover-uri-test
   (testing "should generate a valid rollover URI"

--- a/test/clj_momo/lib/es/index_test.clj
+++ b/test/clj_momo/lib/es/index_test.clj
@@ -3,7 +3,8 @@
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [clj-momo.lib.es
              [conn :as es-conn]
-             [index :as es-index]]
+             [index :as es-index]
+             [document :as es-doc]]
             [test-helpers.core :as th]))
 
 (use-fixtures :once
@@ -19,6 +20,18 @@
   (testing "should generate a valid template URI"
     (is (= (es-index/template-uri "http://127.0.0.1" "test")
            "http://127.0.0.1/_template/test"))))
+
+(deftest rollover-uri-test
+  (testing "should generate a valid rollover URI"
+    (is (= (es-index/rollover-uri "http://127.0.0.1" "test")
+           "http://127.0.0.1/test/_rollover"))
+    (is (= (es-index/rollover-uri "http://127.0.0.1" "test" nil true)
+           "http://127.0.0.1/test/_rollover?dry_run"))
+    (is (= (es-index/rollover-uri "http://127.0.0.1" "test" "test2" true)
+           "http://127.0.0.1/test/_rollover/test2?dry_run"))
+    (is (= (es-index/rollover-uri "http://127.0.0.1" "test" "test2" false)
+           "http://127.0.0.1/test/_rollover/test2"))))
+
 
 (deftest ^:integration index-crud-ops
   (testing "with ES conn test setup"
@@ -40,8 +53,8 @@
 
           (is (true? (boolean index-create-res)))
           (is (= {:test_index
-                  {:aliases {},
-                   :mappings {},
+                  {:aliases {}
+                   :mappings {}
                    :settings
                    {:index
                     {:number_of_shards "1"
@@ -57,3 +70,78 @@
           (is (= {:acknowledged true} index-open-res))
           (is (= {:acknowledged true} index-close-res))
           (is (true? (boolean index-delete-res))))))))
+
+(deftest ^:integration rollover-test
+  (let [conn (es-conn/connect (th/get-es-config))]
+    (es-index/delete! conn "test_index-*")
+    (es-index/create! conn
+                      "test_index-1"
+                      {:settings {:number_of_shards 1
+                                  :number_of_replicas 1}
+                       :aliases {:test_alias {}}})
+    (testing "rollover should not be applied if conditions are not matched"
+      (is (= {:rolled_over false :dry_run false}
+             (-> (es-index/rollover! conn "test_alias" {:max_age "1d" :max_docs 3})
+                 (select-keys [:rolled_over :dry_run]))))
+      (is (false? (es-index/index-exists? conn "test_index-000002"))))
+
+    (is (= {:rolled_over false :dry_run true}
+           (-> (es-index/rollover! conn
+                                   "test_alias"
+                                   {:max_age "1d" :max_docs 3}
+                                   {}
+                                   nil
+                                   true)
+               (select-keys [:rolled_over :dry_run])))
+        "rollover dry_run paramater should be properly applied")
+
+    ;; add 3 documents to trigger max-doc condition
+    (es-doc/bulk-create-doc conn
+                            (repeat 3 {:_index "test_alias"
+                                       :_type "whatever"
+                                       :foo :bar})
+                            "true")
+
+    (testing "rollover dry_run parameter should be properly applied when condition is met"
+      (let [{:keys [rolled_over dry_run old_index new_index]}
+            (es-index/rollover! conn
+                                "test_alias"
+                                {:max_age "1d" :max_docs 3}
+                                {}
+                                nil
+                                true)]
+        (is (false? rolled_over))
+        (is dry_run)
+        (is (= old_index "test_index-1"))
+        (is (= new_index "test_index-000002"))
+        (is (false? (es-index/index-exists? conn new_index)))))
+
+    (is (= "test_index_new"
+           (:new_index (es-index/rollover! conn
+                                           "test_alias"
+                                           {:max_age "1d" :max_docs 3}
+                                           {}
+                                           "test_index_new"
+                                           true)))
+        "new_index should be equal to the name passed as parameter")
+
+    (testing "rollover should be properly applied when condition is met and dry run set to false"
+      (let [{:keys [rolled_over dry_run old_index new_index]}
+            (es-index/rollover! conn
+                                "test_alias"
+                                {:max_age "1d" :max_docs 3}
+                                {:number_of_shards 2
+                                 :number_of_replicas 3}
+                                nil
+                                false)
+            {:keys [number_of_shards
+                    number_of_replicas]} (get-in (es-index/get conn new_index)
+                                                 [(keyword new_index) :settings :index])]
+        (is rolled_over)
+        (is (false? dry_run))
+        (is (= old_index "test_index-1"))
+        (is (= new_index "test_index-000002"))
+        (is (= "2" number_of_shards))
+        (is (= "3" number_of_replicas))))
+
+    (es-index/delete! conn "test_index-*")))

--- a/test/clj_momo/lib/es/query_test.clj
+++ b/test/clj_momo/lib/es/query_test.clj
@@ -2,6 +2,7 @@
   (:require [clj-momo.lib.es.query :as q]
             [clojure.test :refer :all]))
 
+
 (deftest prepare-terms
   (let [simple-keys {:a 1 :b [2 3]}
         nested-keys {[:a :b] 1
@@ -37,3 +38,11 @@
   (is (= (q/bool {:filter [{:match_all {}}]})
          bool-query3)
       "filter-map->bool-query with every empty params should return a bool query with only formatted all-of elements in filter clause")))
+
+(deftest ids-test
+  (is (= {:ids {:values ["id1" "id2" "id3"]}}
+         (q/ids ["id1" "id2" "id3"])))
+  (is (= {:ids {:values ["id1"]}}
+         (q/ids ["id1"])))
+  (is (= {:ids {:values []}}
+         (q/ids []))))

--- a/test/clj_momo/lib/schema_test.clj
+++ b/test/clj_momo/lib/schema_test.clj
@@ -11,5 +11,4 @@
 
 (deftest test-keys
   (is (= #{:foo "bar" :spam "eggs"}
-         (set (sut/keys example-schema))))
-  )
+         (set (sut/keys example-schema)))))


### PR DESCRIPTION
This PR is related to https://github.com/threatgrid/iroh/issues/2737.

- It enables to return full hits in elasticsearch document/query. Along with ids query it enable to determine in which index is a document when querying an alias that points to multiple indices.

- Support of [rollover API](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/indices-rollover-index.html)

- [delete by query](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-delete-by-query.html).

- [refresh on _all indices](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/indices-refresh.html).
 
- [ids queries](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-ids-query.html).