### PR TITLE
removes default _uid sort which uses fielddata

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-momo "0.2.33-SNAPSHOT"
+(defproject threatgrid/clj-momo "0.3.0-SNAPSHOT"
   :description "Library code produced by the Cisco ThreatGrid team for building swagger backed API services"
   :url "https://github.com/threatgrid/clj-momo"
   :license {:name "Eclipse Public License"

--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -256,19 +256,16 @@
   [sort_by sort_order]
   (let [sort-fields
         (map (fn [field]
-               (let [sp (clojure.string/split field #":")]
-                 {(first sp)
-                  {:order (or (second sp)
-                              sort_order)}}))
+               (let [[field-name field-order] (clojure.string/split field #":")]
+                 {(keyword field-name)
+                  {:order (keyword (or field-order sort_order))}}))
              (clojure.string/split (name sort_by) #","))]
 
     {:sort (into {} sort-fields)}))
 
 (defn params->pagination
   [{:keys [sort_by sort_order offset limit search_after]
-    :or {sort_by :_uid
-         sort_order :asc
-         offset 0
+    :or {sort_order :asc
          limit pagination/default-limit}}]
   (merge
    {}

--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -257,7 +257,7 @@
   (let [sort-fields
         (map (fn [field]
                (let [[field-name field-order] (clojure.string/split field #":")]
-                 {(keyword field-name)
+                 {field-name
                   {:order (keyword (or field-order sort_order))}}))
              (clojure.string/split (name sort_by) #","))]
 

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -66,32 +66,32 @@
 
 (deftest params->pagination-test
   (is (= {:size 100
-          :sort {:field1 {:order :asc}}}
+          :sort {"field1" {:order :asc}}}
          (es-doc/params->pagination {:sort_by :field1})))
 
   (is (= {:size 100
-          :sort {:field1 {:order :desc}}}
+          :sort {"field1" {:order :desc}}}
          (es-doc/params->pagination {:sort_by "field1:desc"})
          (es-doc/params->pagination {:sort_by "field1:desc"
                                      :sort_order :asc})))
 
   (is (= {:size 100
-          :sort {:field1 {:order :desc}
-                 :field2 {:order :asc}
-                 :field3 {:order :desc}}}
+          :sort {"field1" {:order :desc}
+                 "field2" {:order :asc}
+                 "field3" {:order :desc}}}
          (es-doc/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"})
          (es-doc/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"
                                      :sort_order :asc})))
 
   (is (= {:size 100
           :from 1000
-          :sort {:field1 {:order :asc}}}
+          :sort {"field1" {:order :asc}}}
          (es-doc/params->pagination {:sort_by :field1
                                      :offset 1000})))
 
   (is (= {:size 10000
           :from 1000
-          :sort {:field1 {:order :asc}}}
+          :sort {"field1" {:order :asc}}}
          (es-doc/params->pagination {:sort_by :field1
                                      :offset 1000
                                      :limit 10000})))
@@ -99,7 +99,7 @@
   (is (= {:size 10000
           :from 0
           :search_after ["value1"]
-          :sort {:field1 {:order :asc}}}
+          :sort {"field1" {:order :asc}}}
          (es-doc/params->pagination {:sort_by :field1
                                      :offset 1000
                                      :limit 10000

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -63,6 +63,51 @@
                                 42)
          "http://127.0.0.1/test_index/test_mapping/test/_update?retry_on_conflict=42"))  )
 
+
+(deftest params->pagination-test
+  (is (= {:size 100
+          :sort {:field1 {:order :asc}}}
+         (es-doc/params->pagination {:sort_by :field1})))
+
+  (is (= {:size 100
+          :sort {:field1 {:order :desc}}}
+         (es-doc/params->pagination {:sort_by "field1:desc"})
+         (es-doc/params->pagination {:sort_by "field1:desc"
+                                     :sort_order :asc})))
+
+  (is (= {:size 100
+          :sort {:field1 {:order :desc}
+                 :field2 {:order :asc}
+                 :field3 {:order :desc}}}
+         (es-doc/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"})
+         (es-doc/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"
+                                     :sort_order :asc})))
+
+  (is (= {:size 100
+          :from 1000
+          :sort {:field1 {:order :asc}}}
+         (es-doc/params->pagination {:sort_by :field1
+                                     :offset 1000})))
+
+  (is (= {:size 10000
+          :from 1000
+          :sort {:field1 {:order :asc}}}
+         (es-doc/params->pagination {:sort_by :field1
+                                     :offset 1000
+                                     :limit 10000})))
+
+  (is (= {:size 10000
+          :from 0
+          :search_after ["value1"]
+          :sort {:field1 {:order :asc}}}
+         (es-doc/params->pagination {:sort_by :field1
+                                     :offset 1000
+                                     :limit 10000
+                                     :search_after ["value1"]})
+         (es-doc/params->pagination {:sort_by :field1
+                                     :limit 10000
+                                     :search_after ["value1"]}))))
+
 (deftest ^:integration document-crud-ops
   (testing "with ES conn test setup"
     (let [conn (es-conn/connect


### PR DESCRIPTION
> Related # https://github.com/threatgrid/iroh/issues/2871

This PR removes default `:_uid` sort param and introduces tests for `params->pagination` function.