### PR TITLE
Fix the update-doc

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-momo "0.3.2-SNAPSHOT"
+(defproject threatgrid/clj-momo "0.3.3-SNAPSHOT"
   :description "Library code produced by the Cisco ThreatGrid team for building swagger backed API services"
   :url "https://github.com/threatgrid/clj-momo"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,7 @@
                  [riemann-clojure-client "0.4.5"
                   ;; Protobuf-java is brought in by ClojureScript
                   :exclusions [com.google.protobuf/protobuf-java]]]
+
   :main nil
 
   :codox {:output-path "doc"}
@@ -63,5 +64,6 @@
                    :all (constantly true)}
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojurescript "1.9.946"]]
+                                  [org.clojure/clojurescript "1.9.946"]
+                                  [ch.qos.logback/logback-classic "1.2.3"]]
                    :resource-paths ["test/resources"]}})

--- a/src/clj_momo/lib/es/document.clj
+++ b/src/clj_momo/lib/es/document.clj
@@ -22,11 +22,6 @@
   [uri index-name mapping id]
   (str (url uri (url-encode index-name) (url-encode mapping) (url-encode id))))
 
-(defn create-doc-uri
-  "make an uri for document index"
-  [uri index-name mapping id]
-  (str (url (index-doc-uri uri index-name mapping id) "_create")))
-
 (def delete-doc-uri
   "make an uri for doc deletion"
   index-doc-uri)

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -42,15 +42,15 @@
                                        ["ctim", "ctia"]
                                        "malware")))))
 
-(deftest create-doc-uri-test
+(deftest index-doc-uri-test
   (testing "should generate a valid doc URI"
-    (is (= "http://127.0.0.1/test_index/test_mapping/test/_create"
-           (es-doc/create-doc-uri "http://127.0.0.1"
+    (is (= "http://127.0.0.1/test_index/test_mapping/test"
+           (es-doc/index-doc-uri "http://127.0.0.1"
                                   "test_index"
                                   "test_mapping"
                                   "test")))
-    (is (= "http://127.0.0.1/test_index/test_mapping/test%2Ffoo%2Fbar/_create"
-           (es-doc/create-doc-uri "http://127.0.0.1"
+    (is (= "http://127.0.0.1/test_index/test_mapping/test%2Ffoo%2Fbar"
+           (es-doc/index-doc-uri "http://127.0.0.1"
                                   "test_index"
                                   "test_mapping"
                                   "test/foo/bar")))))

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -157,6 +157,13 @@
                                       sample-doc
                                       "true")))
             (is (= sample-doc (get-sample-doc)))
+            (testing "existing doc"
+              (is (thrown? clojure.lang.ExceptionInfo
+                           (es-doc/create-doc conn
+                                              "test_index"
+                                              "test_mapping"
+                                              sample-doc
+                                              "true"))))
             (testing "with field selection"
               (is (= {:foo "bar is a lie"}
                      (es-doc/get-doc conn

--- a/test/clj_momo/lib/es/document_test.clj
+++ b/test/clj_momo/lib/es/document_test.clj
@@ -171,57 +171,54 @@
                                      "test_mapping"
                                      (:id sample-doc)
                                      {:_source ["foo"]})))))
-          (testing "patch-doc"
-            (let [patch1 {:test_value 44}
-                  patched-doc1 (into sample-doc patch1)
-                  patch2 {:test_value 55}
-                  patched-doc2 (into sample-doc patch2)]
-              (is (= patched-doc1
-                     (es-doc/patch-doc conn
-                                       "test_index"
-                                       "test_mapping"
-                                       (:id sample-doc)
-                                       patch1
-                                       "true")))
-              (is (= patched-doc1 (get-sample-doc)))
+          (testing "update-doc"
+            (let [update1 {:test_value 44}
+                  updated-doc1 (into sample-doc update1)
+                  update2 {:test_value 55}
+                  updated-doc2 (into sample-doc update2)]
+              (is (= updated-doc1
+                     (es-doc/update-doc conn
+                                        "test_index"
+                                        "test_mapping"
+                                        (:id sample-doc)
+                                        update1
+                                        "true")))
+              (is (= updated-doc1 (get-sample-doc)))
               (testing "with params"
-                (is (= patched-doc2
-                       (es-doc/patch-doc conn
+                (is (= updated-doc2
+                       (es-doc/update-doc conn
+                                          "test_index"
+                                          "test_mapping"
+                                          (:id sample-doc)
+                                          update2
+                                          "true"
+                                          {:retry-on-conflict 10})))
+                (is (= updated-doc2 (get-sample-doc))))))
+          (testing "index-doc"
+            (testing "updating a field"
+              (let [indexed-doc (assoc sample-doc :test_value 66)]
+                (is (= indexed-doc
+                       (es-doc/index-doc conn
                                          "test_index"
                                          "test_mapping"
-                                         (:id sample-doc)
-                                         patch2
-                                         "true"
-                                         {:retry-on-conflict 10})))
-                (is (= patched-doc2 (get-sample-doc))))))
-          (testing "update-doc"
-            (testing "updating a field"
-              (let [updated-doc (assoc sample-doc :test_value 66)]
-                (is (= updated-doc
-                       (es-doc/update-doc conn
-                                          "test_index"
-                                          "test_mapping"
-                                          (:id sample-doc)
-                                          updated-doc
-                                          "true")))
-                (is (= updated-doc (get-sample-doc)))))
+                                         indexed-doc
+                                         "true")))
+                (is (= indexed-doc (get-sample-doc)))))
             (testing "removing a field"
-              (let [updated-doc (dissoc sample-doc :test_value)]
-                (is (= updated-doc
-                       (es-doc/update-doc conn
-                                          "test_index"
-                                          "test_mapping"
-                                          (:id sample-doc)
-                                          updated-doc
-                                          "true")))
-                (is (= updated-doc (get-sample-doc)))
+              (let [indexed-doc (dissoc sample-doc :test_value)]
+                (is (= indexed-doc
+                       (es-doc/index-doc conn
+                                         "test_index"
+                                         "test_mapping"
+                                         indexed-doc
+                                         "true")))
+                (is (= indexed-doc (get-sample-doc)))
                 ;; restore with the initial values
-                (es-doc/update-doc conn
-                                   "test_index"
-                                   "test_mapping"
-                                   (:id sample-doc)
-                                   sample-doc
-                                   "true"))))
+                (es-doc/index-doc conn
+                                  "test_index"
+                                  "test_mapping"
+                                  sample-doc
+                                  "true"))))
           (testing "bulk-create-doc"
             (is (= sample-docs
                    (es-doc/bulk-create-doc conn

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="riemann-reporter" level="error"/>
+
+    <root level="warn">
+        <!-- >appender-ref ref="STDOUT" /-->
+    </root>
+</configuration>


### PR DESCRIPTION
> Related https://github.com/threatgrid/iroh/issues/3062

This PR adds an `index-doc` function. `update-doc` behaves like a patch. It's not possible to remove a field for instance. With the `index-doc` fn  a whole doc can be updated.

Additional changes:
- Adding a logback configuration file for the test profile
- Adding a `index-fn` that uses the Index API to update a full doc
- The `create-fn` can only be used to create a new. document, an exception is thrown if the document already exists

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.