### PR TITLE
Fix deep-merge when the last map is nil

### DIFF
--- a/src/clj_momo/lib/map.cljc
+++ b/src/clj_momo/lib/map.cljc
@@ -54,8 +54,9 @@
                      {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
   -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}"
   [f & maps]
-  (if (every? map? maps)
-    (apply merge-with (partial deep-merge-with f) maps)
-    (apply f maps)))
+  (let [maps (filter identity maps)]
+    (if (every? map? maps)
+      (apply merge-with (partial deep-merge-with f) maps)
+      (apply f maps))))
 
 (def deep-merge (partial deep-merge-with (fn [& args] (last args))))

--- a/test/clj_momo/lib/map_test.clj
+++ b/test/clj_momo/lib/map_test.clj
@@ -22,4 +22,7 @@
               :ab "ok"
               :ac {:aca "ok"
                    :acb "ok"
-                   :acc "ok"}}})))
+                   :acc "ok"}}}))
+  (is (= {:a :b} (sut/deep-merge nil {:a :b})))
+  (is (= {:a :b} (sut/deep-merge {:a :b} nil)))
+  (is (nil? (sut/deep-merge nil nil))))

--- a/test/clj_momo/lib/map_test.clj
+++ b/test/clj_momo/lib/map_test.clj
@@ -1,6 +1,6 @@
 (ns clj-momo.lib.map-test
   (:require [clj-momo.lib.map :as sut]
-            [clojure.test :refer [deftest is]]))
+            [clojure.test :refer [deftest is are testing]]))
 
 (deftest test-assoc-if
   (is {:a 10 :c 3}
@@ -31,4 +31,24 @@
   (is (= {:a {:c :d}}
          (sut/deep-merge {:a :b} {:a {:c :d}})))
   (is (= {:a :b}
-         (sut/deep-merge {:a {:c :d}} {:a :b}))))
+         (sut/deep-merge {:a {:c :d}} {:a :b})))
+  (is (= {:a {:b {:x :y}}}
+         (sut/deep-merge {:a {:b :c}}
+                         nil
+                         {:a nil}
+                         {:a {:b {:x :y}}})))
+  (is (= {:a :b} (sut/deep-merge {:a :b})))
+  (testing "m1 is a hashmap and m2 is different"
+    (are [x m2] (= x
+                   (sut/deep-merge {:a :b}  m2))
+      {:a :b} nil
+      :c      :c
+      {:a :b
+       :c :d} {:c :d}))
+  (testing "m2 is a hashmap and m1 is different"
+    (are [x m1] (= x
+                   (sut/deep-merge m1 {:a :b}))
+      {:a :b} nil
+      {:a :b} :c
+      {:a :b
+       :c :d} {:c :d})))

--- a/test/clj_momo/lib/map_test.clj
+++ b/test/clj_momo/lib/map_test.clj
@@ -37,18 +37,43 @@
                          nil
                          {:a nil}
                          {:a {:b {:x :y}}})))
-  (is (= {:a :b} (sut/deep-merge {:a :b})))
-  (testing "m1 is a hashmap and m2 is different"
-    (are [x m2] (= x
-                   (sut/deep-merge {:a :b}  m2))
-      {:a :b} nil
-      :c      :c
-      {:a :b
-       :c :d} {:c :d}))
-  (testing "m2 is a hashmap and m1 is different"
-    (are [x m1] (= x
-                   (sut/deep-merge m1 {:a :b}))
-      {:a :b} nil
-      {:a :b} :c
-      {:a :b
-       :c :d} {:c :d})))
+  (is (= {:c1 {:a :b}
+          :c2 {:a :b}
+          :c3 :c3
+          :c4 {:a :b :x :y}
+          :d1 :v
+          :d2 :v
+          :d3 :d3
+          :d4 {:x :y}
+          :e1 nil
+          :e2 nil
+          :e3 :e3
+          :e4 {:x :y}
+          :f2 nil
+          :f3 :f3
+          :f4 {:x :y}}
+         (sut/deep-merge
+          {:c1 {:a :b}
+           :c2 {:a :b}
+           :c3 {:a :b}
+           :c4 {:a :b}
+           :d1 :v
+           :d2 :v
+           :d3 :v
+           :d4 :v
+           :e1 nil
+           :e2 nil
+           :e3 nil
+           :e4 nil}
+          {:c2 nil
+           :c3 :c3
+           :c4 {:x :y}
+           :d2 nil
+           :d3 :d3
+           :d4 {:x :y}
+           :e2 nil
+           :e3 :e3
+           :e4 {:x :y}
+           :f2 nil
+           :f3 :f3
+           :f4 {:x :y}}))))

--- a/test/clj_momo/lib/map_test.clj
+++ b/test/clj_momo/lib/map_test.clj
@@ -25,4 +25,10 @@
                    :acc "ok"}}}))
   (is (= {:a :b} (sut/deep-merge nil {:a :b})))
   (is (= {:a :b} (sut/deep-merge {:a :b} nil)))
-  (is (nil? (sut/deep-merge nil nil))))
+  (is (nil? (sut/deep-merge nil nil)))
+  (is (= {:a {:b :c}}
+         (sut/deep-merge {:a {:b :c}} {:a nil})))
+  (is (= {:a {:c :d}}
+         (sut/deep-merge {:a :b} {:a {:c :d}})))
+  (is (= {:a :b}
+         (sut/deep-merge {:a {:c :d}} {:a :b}))))


### PR DESCRIPTION
`(deep-merge {:a :b} nil) => nil`

it should return `{:a :b}`

This PR fixes it. I found the solution in this stackoverflow comment https://stackoverflow.com/a/27214324