### PR TITLE
Revert Fix deep-merge when the last map is nil (#73)

### DIFF
--- a/src/clj_momo/lib/map.cljc
+++ b/src/clj_momo/lib/map.cljc
@@ -54,9 +54,8 @@
                      {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
   -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}"
   [f & maps]
-  (let [maps (filter identity maps)]
-    (if (every? map? maps)
-      (apply merge-with (partial deep-merge-with f) maps)
-      (apply f maps))))
+  (if (every? map? maps)
+    (apply merge-with (partial deep-merge-with f) maps)
+    (apply f maps)))
 
 (def deep-merge (partial deep-merge-with (fn [& args] (last args))))

--- a/test/clj_momo/lib/map_test.clj
+++ b/test/clj_momo/lib/map_test.clj
@@ -1,6 +1,6 @@
 (ns clj-momo.lib.map-test
   (:require [clj-momo.lib.map :as sut]
-            [clojure.test :refer [deftest is are testing]]))
+            [clojure.test :refer [deftest is]]))
 
 (deftest test-assoc-if
   (is {:a 10 :c 3}
@@ -22,58 +22,4 @@
               :ab "ok"
               :ac {:aca "ok"
                    :acb "ok"
-                   :acc "ok"}}}))
-  (is (= {:a :b} (sut/deep-merge nil {:a :b})))
-  (is (= {:a :b} (sut/deep-merge {:a :b} nil)))
-  (is (nil? (sut/deep-merge nil nil)))
-  (is (= {:a {:b :c}}
-         (sut/deep-merge {:a {:b :c}} {:a nil})))
-  (is (= {:a {:c :d}}
-         (sut/deep-merge {:a :b} {:a {:c :d}})))
-  (is (= {:a :b}
-         (sut/deep-merge {:a {:c :d}} {:a :b})))
-  (is (= {:a {:b {:x :y}}}
-         (sut/deep-merge {:a {:b :c}}
-                         nil
-                         {:a nil}
-                         {:a {:b {:x :y}}})))
-  (is (= {:c1 {:a :b}
-          :c2 {:a :b}
-          :c3 :c3
-          :c4 {:a :b :x :y}
-          :d1 :v
-          :d2 :v
-          :d3 :d3
-          :d4 {:x :y}
-          :e1 nil
-          :e2 nil
-          :e3 :e3
-          :e4 {:x :y}
-          :f2 nil
-          :f3 :f3
-          :f4 {:x :y}}
-         (sut/deep-merge
-          {:c1 {:a :b}
-           :c2 {:a :b}
-           :c3 {:a :b}
-           :c4 {:a :b}
-           :d1 :v
-           :d2 :v
-           :d3 :v
-           :d4 :v
-           :e1 nil
-           :e2 nil
-           :e3 nil
-           :e4 nil}
-          {:c2 nil
-           :c3 :c3
-           :c4 {:x :y}
-           :d2 nil
-           :d3 :d3
-           :d4 {:x :y}
-           :e2 nil
-           :e3 :e3
-           :e4 {:x :y}
-           :f2 nil
-           :f3 :f3
-           :f4 {:x :y}}))))
+                   :acc "ok"}}})))


### PR DESCRIPTION
The new behaviour breaks some code in iroh. I prefer revert this change.