### PR TITLE
Bump clj-http to 3.12.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,13 @@ before_install:
     - echo "127.0.0.1 "`hostname` | sudo tee /etc/hosts
 
     # install docker-compose if not in cache
-    - if [ ! -f $COMPOSE_BIN ]; then curl -L {$COMPOSE_URI}/docker-compose-`uname -s`-`uname -m` > $COMPOSE_BIN; fi
+    - if [ ! -f $COMPOSE_BIN ]; then curl -L {$COMPOSE_URI}/docker-compose-`uname -s`-`uname -m` -o $COMPOSE_BIN; fi
     - chmod +x $COMPOSE_BIN 
 
 before_script:
     - $COMPOSE_BIN -f containers/dev/docker-compose.yml up -d > $COMPOSE_LOG
     # Wait ES
-    - until curl http://127.0.0.1:9200/; do sleep 1; done
+    - until curl http://127.0.0.1:9205/; do sleep 1; done
 
 services:
     - docker 
@@ -39,6 +39,6 @@ env:
     global:
       - LOG_DIR=$HOME/log
       - BIN_DIR=$HOME/bin
-      - COMPOSE_URI=https://github.com/docker/compose/releases/download/1.25.3
-      - COMPOSE_BIN=$HOME/bin/docker-compose-1-25-3
+      - COMPOSE_URI=https://github.com/docker/compose/releases/download/v2.17.2
+      - COMPOSE_BIN=$HOME/bin/docker-compose-2-17-2
       - COMPOSE_LOG=$HOME/log/docker-compose.log

--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -1,7 +1,11 @@
-elasticsearch-dev:
-  image: elasticsearch:5.1
-  environment:
-    - cluster.name=elasticsearch
-  ports:
-    - "9200:9200"
-    - "9300:9300"
+version: '2'
+services:
+  elasticsearch-dev:
+    image: elasticsearch:5.6.11
+    environment:
+      - xpack.security.enabled=false
+      - cluster.name=elasticsearch
+      - discovery.type=single-node
+    ports:
+      - "9205:9200"
+      - "9305:9300"

--- a/containers/dev/m1-docker-compose.yml
+++ b/containers/dev/m1-docker-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  elasticsearch5:
+    build: ./m1-images/elasticsearch5

--- a/containers/dev/m1-images/elasticsearch5/Dockerfile
+++ b/containers/dev/m1-images/elasticsearch5/Dockerfile
@@ -1,0 +1,45 @@
+# This Dockerfile was generated from templates/Dockerfile.j2
+
+FROM centos:7
+LABEL maintainer "Elastic Docker Team <docker@elastic.co>"
+
+ENV ELASTIC_CONTAINER true
+ENV PATH /usr/share/elasticsearch/bin:$PATH
+ENV JAVA_HOME /usr/lib/jvm/jre-1.8.0-openjdk
+
+RUN yum update -y && yum install -y java-1.8.0-openjdk-headless wget which && yum clean all
+
+RUN groupadd -g 1000 elasticsearch && adduser -u 1000 -g 1000 -d /usr/share/elasticsearch elasticsearch
+
+WORKDIR /usr/share/elasticsearch
+
+USER elasticsearch
+
+# Download and extract defined ES version.
+RUN curl -fsSL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.tar.gz | \
+    tar zx --strip-components=1
+
+RUN set -ex && for esdirs in config data logs; do \
+        mkdir -p "$esdirs"; \
+    done
+
+# Install x-pack and also the ingest-{agent,geoip} modules required for Filebeat
+RUN for PLUGIN in x-pack ingest-user-agent ingest-geoip; do \
+      elasticsearch-plugin install --batch "$PLUGIN"; \
+    done
+COPY elasticsearch.yml log4j2.properties config/
+COPY x-pack/log4j2.properties config/x-pack/
+COPY bin/es-docker bin/es-docker
+
+USER root
+RUN chown elasticsearch:elasticsearch \
+      config/elasticsearch.yml \
+      config/log4j2.properties \
+      config/x-pack/log4j2.properties \
+      bin/es-docker && \
+    chmod 0750 bin/es-docker
+
+USER elasticsearch
+CMD ["/bin/bash", "bin/es-docker"]
+
+EXPOSE 9200 9300

--- a/containers/dev/m1-images/elasticsearch5/bin/es-docker
+++ b/containers/dev/m1-images/elasticsearch5/bin/es-docker
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Run Elasticsearch and allow setting default settings via env vars
+#
+# e.g. Setting the env var cluster.name=testcluster
+#
+# will cause Elasticsearch to be invoked with -Ecluster.name=testcluster
+#
+# see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+
+declare -a es_opts
+
+while IFS='=' read -r envvar_key envvar_value
+do
+
+    # Elasticsearch settings need to have at least two dot separated lowercase
+    # words, e.g. `cluster.name`, except for `processors` which we handle
+    # specially
+    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ || "$envvar_key" == "processors" ]]; then
+        if [[ ! -z $envvar_value ]]; then
+          es_opt="-E${envvar_key}=${envvar_value}"
+          es_opts+=("${es_opt}")
+        fi
+    fi
+done < <(env)
+
+# The virtual file /proc/self/cgroup should list the current cgroup
+# membership. For each hierarchy, you can follow the cgroup path from
+# this file to the cgroup filesystem (usually /sys/fs/cgroup/) and
+# introspect the statistics for the cgroup for the given
+# hierarchy. Alas, Docker breaks this by mounting the container
+# statistics at the root while leaving the cgroup paths as the actual
+# paths. Therefore, Elasticsearch provides a mechanism to override
+# reading the cgroup path from /proc/self/cgroup and instead uses the
+# cgroup path defined the JVM system property
+# es.cgroups.hierarchy.override. Therefore, we set this value here so
+# that cgroup statistics are available for the container this process
+# will run in.
+export ES_JAVA_OPTS="-Des.cgroups.hierarchy.override=/ $ES_JAVA_OPTS"
+
+exec bin/elasticsearch "${es_opts[@]}"

--- a/containers/dev/m1-images/elasticsearch5/elasticsearch.yml
+++ b/containers/dev/m1-images/elasticsearch5/elasticsearch.yml
@@ -1,0 +1,9 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+xpack.ml.enabled: false

--- a/containers/dev/m1-images/elasticsearch5/log4j2.properties
+++ b/containers/dev/m1-images/elasticsearch5/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/containers/dev/m1-images/elasticsearch5/x-pack/log4j2.properties
+++ b/containers/dev/m1-images/elasticsearch5/x-pack/log4j2.properties
@@ -1,0 +1,3 @@
+logger.xpack_security_audit_logfile.name = org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail
+logger.xpack_security_audit_logfile.appenderRef.console.ref = console
+logger.xpack_security_audit_logfile.level = info

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [clj-time "0.15.2"]
                  [com.arohner/uri "0.1.2"]
                  [cheshire "5.9.0"]
-                 [clj-http "3.10.1"]
+                 [clj-http "3.12.3"]
                  [slugger "1.0.1"]
                  [riemann-clojure-client "0.5.1"]
                  [metrics-clojure ~metrics-clojure-version]

--- a/test/resources/default-test.properties
+++ b/test/resources/default-test.properties
@@ -1,4 +1,4 @@
 # These are properties used to configure tests
 # (Where the properties code is not the system under test)
-es.host=127.0.0.1
-es.port=9200
+es.host=localhost
+es.port=9205


### PR DESCRIPTION
- Bump to clj-http 3.12.3
- Slightly upgrade the docker-compose setup adding support for M1 cpus